### PR TITLE
feat: subscriber for gps/fix to set LLA

### DIFF
--- a/param/xsens_mti_node.yaml
+++ b/param/xsens_mti_node.yaml
@@ -11,6 +11,7 @@
 
 publisher_queue_size: 5
 fix_topic_name: "/alpha_rise/gps/fix"
+use_fix_topic_to_set_lla: true
 # TF transform frame_id (default: imu_link), you may want to change it if you use multiple devices
 #frame_id: "imu_link"
 

--- a/param/xsens_mti_node.yaml
+++ b/param/xsens_mti_node.yaml
@@ -10,7 +10,7 @@
 # log_file: log.mtb
 
 publisher_queue_size: 5
-
+fix_topic_name: "/alpha_rise/gps/fix"
 # TF transform frame_id (default: imu_link), you may want to change it if you use multiple devices
 #frame_id: "imu_link"
 
@@ -21,15 +21,15 @@ pub_mag: true
 pub_angular_velocity: true
 pub_acceleration: true
 pub_free_acceleration: true
-pub_dq: true
-pub_dv: true
-pub_sampletime: true
-pub_temperature: true
-pub_pressure: true
-pub_gnss: true
-pub_twist: true
+pub_dq: false
+pub_dv: false
+pub_sampletime: false
+pub_temperature: false
+pub_pressure: false
+pub_gnss: false
+pub_twist: false
 pub_transform: true
-pub_positionLLA: true
+pub_positionLLA: false
 pub_velocity: true
 pub_euler: true
 pub_raw_mag: false

--- a/param/xsens_mti_node.yaml
+++ b/param/xsens_mti_node.yaml
@@ -10,8 +10,8 @@
 # log_file: log.mtb
 
 publisher_queue_size: 5
-fix_topic_name: "/alpha_rise/gps/fix"
-use_fix_topic_to_set_lla: true
+gps_fix_topic: "/alpha_rise/gps/fix"
+set_lla_with_gps_fix: true
 # TF transform frame_id (default: imu_link), you may want to change it if you use multiple devices
 #frame_id: "imu_link"
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -32,7 +32,6 @@
 
 #include <ros/ros.h>
 #include "xdainterface.h"
-
 #include <iostream>
 #include <stdexcept>
 #include <string>
@@ -49,6 +48,8 @@ int main(int argc, char *argv[])
 	XdaInterface *xdaInterface = new XdaInterface();
 
 	xdaInterface->registerPublishers();
+
+	xdaInterface->registerSubscribers();
 
     xdaInterface->registerServices();
 

--- a/src/xdainterface.cpp
+++ b/src/xdainterface.cpp
@@ -183,6 +183,26 @@ void XdaInterface::registerPublishers()
     }
 }
 
+void XdaInterface::registerSubscribers(){
+    //Initialise GPS_Fix(NavSatFix) Subscriber
+    std::string fix_topic_name; 
+    ros::param::get("/xsens_mti_node/fix_topic_name", fix_topic_name);
+    m_gps_fix_sub = m_nh.subscribe(fix_topic_name, 1,
+                                    &XdaInterface::gps_callback, this);
+}
+
+void XdaInterface::gps_callback(const sensor_msgs::NavSatFix& msg){
+    //NavSatfix callback that calls the setlla service.
+    xsens_mti_driver::SetLLA::Request req;
+    xsens_mti_driver::SetLLA::Response res;
+    
+    req.latitude = msg.latitude;
+    req.longitude = msg.longitude;
+    req.altitude = msg.altitude;
+
+    // std::cout<<req<<std::endl;
+    XdaInterface::setLlaCallback(req,res);
+}
 void XdaInterface::registerServices() {
 
     m_data_record_server = m_pnh.advertiseService(

--- a/src/xdainterface.cpp
+++ b/src/xdainterface.cpp
@@ -186,12 +186,13 @@ void XdaInterface::registerPublishers()
 void XdaInterface::registerSubscribers(){
     //Initialise GPS_Fix(NavSatFix) Subscriber
     std::string fix_topic_name; 
-    ros::param::get("/xsens_mti_node/fix_topic_name", fix_topic_name);
-
-    ros::param::get("/xsens_mti_node/use_fix_topic_to_set_lla", use_fix_topic_to_set_lla);
+    m_pnh.getParam("gps_fix_topic",fix_topic_name);
 
     m_gps_fix_sub = m_nh.subscribe(fix_topic_name, 1,
                                     &XdaInterface::gps_callback, this);
+
+    // Get param to whether or not call the srv with topic.
+    m_pnh.getParam("set_lla_with_gps_fix", set_lla_with_gps_fix);
 }
 
 void XdaInterface::gps_callback(const sensor_msgs::NavSatFix& msg){
@@ -203,7 +204,7 @@ void XdaInterface::gps_callback(const sensor_msgs::NavSatFix& msg){
     req.longitude = msg.longitude;
     req.altitude = msg.altitude;
 
-    if (use_fix_topic_to_set_lla){
+    if (set_lla_with_gps_fix){
         // std::cout<<req<<std::endl;
         XdaInterface::setLlaCallback(req,res);
     }

--- a/src/xdainterface.cpp
+++ b/src/xdainterface.cpp
@@ -187,6 +187,9 @@ void XdaInterface::registerSubscribers(){
     //Initialise GPS_Fix(NavSatFix) Subscriber
     std::string fix_topic_name; 
     ros::param::get("/xsens_mti_node/fix_topic_name", fix_topic_name);
+
+    ros::param::get("/xsens_mti_node/use_fix_topic_to_set_lla", use_fix_topic_to_set_lla);
+
     m_gps_fix_sub = m_nh.subscribe(fix_topic_name, 1,
                                     &XdaInterface::gps_callback, this);
 }
@@ -200,9 +203,12 @@ void XdaInterface::gps_callback(const sensor_msgs::NavSatFix& msg){
     req.longitude = msg.longitude;
     req.altitude = msg.altitude;
 
-    // std::cout<<req<<std::endl;
-    XdaInterface::setLlaCallback(req,res);
+    if (use_fix_topic_to_set_lla){
+        // std::cout<<req<<std::endl;
+        XdaInterface::setLlaCallback(req,res);
+    }
 }
+
 void XdaInterface::registerServices() {
 
     m_data_record_server = m_pnh.advertiseService(

--- a/src/xdainterface.h
+++ b/src/xdainterface.h
@@ -93,6 +93,8 @@ private:
     
     ros::Subscriber m_gps_fix_sub;
 
+    bool use_fix_topic_to_set_lla;
+
     bool setLlaCallback(xsens_mti_driver::SetLLA::Request& req,
                         xsens_mti_driver::SetLLA::Response& resp);
 

--- a/src/xdainterface.h
+++ b/src/xdainterface.h
@@ -61,7 +61,7 @@ public:
 
     void spinFor(std::chrono::milliseconds timeout);
     void registerPublishers();
-
+    void registerSubscribers();
     void registerServices();
 
     bool connectDevice();
@@ -90,6 +90,8 @@ private:
     ros::ServiceServer m_stop_recording_server;
 
     ros::ServiceServer m_calibrate_server;
+    
+    ros::Subscriber m_gps_fix_sub;
 
     bool setLlaCallback(xsens_mti_driver::SetLLA::Request& req,
                         xsens_mti_driver::SetLLA::Response& resp);
@@ -103,6 +105,7 @@ private:
     bool sendRawCallback(xsens_mti_driver::SendCalibration::Request& req,
                          xsens_mti_driver::SendCalibration::Response& resp);
 
+    void gps_callback(const sensor_msgs::NavSatFix &msg);
 };
 
 #endif

--- a/src/xdainterface.h
+++ b/src/xdainterface.h
@@ -93,7 +93,7 @@ private:
     
     ros::Subscriber m_gps_fix_sub;
 
-    bool use_fix_topic_to_set_lla;
+    bool set_lla_with_gps_fix;
 
     bool setLlaCallback(xsens_mti_driver::SetLLA::Request& req,
                         xsens_mti_driver::SetLLA::Response& resp);


### PR DESCRIPTION
Subscriber node that listens to a fix message. On its callback, it takes in the Lat, Long and Alt and calls the setLLA service.
A param to enable/disable this feature is also added.