### PR TITLE
feat: only subs to gps_fix if set_lla_with_gps_fix is set to True

### DIFF
--- a/src/xdainterface.cpp
+++ b/src/xdainterface.cpp
@@ -188,12 +188,15 @@ void XdaInterface::registerSubscribers(){
     std::string fix_topic_name; 
     m_pnh.getParam("gps_fix_topic",fix_topic_name);
 
-    m_gps_fix_sub = m_nh.subscribe(fix_topic_name, 1,
-                                    &XdaInterface::gps_callback, this);
-
     // Get param to whether or not call the srv with topic.
     m_pnh.getParam("set_lla_with_gps_fix", set_lla_with_gps_fix);
-}
+
+    // Set subscriber only when the param is set to true.
+    if (set_lla_with_gps_fix){
+        m_gps_fix_sub = m_nh.subscribe(fix_topic_name, 1,
+                                    &XdaInterface::gps_callback, this);
+    }
+} 
 
 void XdaInterface::gps_callback(const sensor_msgs::NavSatFix& msg){
     //NavSatfix callback that calls the setlla service.
@@ -204,10 +207,8 @@ void XdaInterface::gps_callback(const sensor_msgs::NavSatFix& msg){
     req.longitude = msg.longitude;
     req.altitude = msg.altitude;
 
-    if (set_lla_with_gps_fix){
-        // std::cout<<req<<std::endl;
-        XdaInterface::setLlaCallback(req,res);
-    }
+    // std::cout<<req<<std::endl;
+    XdaInterface::setLlaCallback(req,res);
 }
 
 void XdaInterface::registerServices() {


### PR DESCRIPTION
Previously the subscriber was initialized irrespective of whether the gps msg was utilized or not. Now, the subscriber is initialized only when set_lla_with_gps_fix is set to True.